### PR TITLE
Implement global theme switching

### DIFF
--- a/src/app/static/board/board.css
+++ b/src/app/static/board/board.css
@@ -1,16 +1,9 @@
 :root {
-    --background-color: #FFFFFF;
-    --surface-color: #FFFFFF;
-    --accent-color: #FF0000;
-    --button-color: #2464DB;
-    --text-color: #181A20;
-    --secondary-text-color: #7D8193;
-    --font-family: 'Inter', sans-serif;
-    --border-radius: 10px;
     --cell-content-size: 0.7;
     --sidebar-width: 280px;
     --gap-size: 12px;
     --font-base: 1rem;
+    --border-radius: 10px;
 }
 
 * {
@@ -66,7 +59,7 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background-color: #F6F8FB;
+    background-color: var(--background-color);
     padding: calc(var(--gap-size) * 1);
     border-radius: var(--border-radius);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
@@ -108,7 +101,7 @@ body {
     overflow-y: auto;
     border: 1px solid #E1E3E8;
     border-radius: var(--border-radius);
-    background-color: #F6F8FB;
+    background-color: var(--background-color);
     -ms-overflow-style: auto;
     scrollbar-width: auto;
 }
@@ -133,11 +126,11 @@ body {
 }
 
 .history-list li.active-history {
-    background-color: #e0f0ff;
+    background-color: var(--surface-color);
 }
 
 .history-list li:hover {
-    background-color: #FFFFFF;
+    background-color: var(--surface-color);
 }
 
 .history-list li:last-child {

--- a/src/app/static/login/login.css
+++ b/src/app/static/login/login.css
@@ -4,32 +4,10 @@
     padding: 0;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background: #181A20;
-        --surface: #22232B;
-        --text-primary: #FFFFFF;
-        --text-secondary: #A3A6B7;
-        --button: #0057fa;
-        --accent-start: #4F8CFF;
-        --accent-end: #B94EFF;
-    }
-}
-@media (prefers-color-scheme: light) {
-    :root {
-        --background: #F6F8FB;
-        --surface: #FFFFFF;
-        --text-primary: #181A20;
-        --text-secondary: #7D8193;
-        --button: #2464DB;
-        --accent-start: #4F8CFF;
-        --accent-end: #B94EFF;
-    }
-}
 
 body {
-    background-color: var(--background);
-    color: var(--text-primary);
+    background-color: var(--background-color);
+    color: var(--text-color);
     font-family: Arial, sans-serif;
     display: flex;
     justify-content: center;
@@ -42,18 +20,18 @@ body {
     top: 20px;
     left: 20px;
     font-size: 20px;
-    color: var(--text-secondary);
+    color: var(--secondary-text-color);
     text-decoration: none;
     z-index: 2;
 }
 
 .back-arrow:hover {
-    color: var(--accent-start);
+    color: var(--accent-color);
 }
 
 .container {
     position: relative;
-    background-color: var(--surface);
+    background-color: var(--surface-color);
     padding: 40px;
     border-radius: 10px;
     box-shadow: 0 4px 10px rgba(0,0,0,0.2);
@@ -75,10 +53,10 @@ h1 {
 .input-group input {
     width: 100%;
     padding: 10px;
-    border: 1px solid var(--text-secondary);
+    border: 1px solid var(--secondary-text-color);
     border-radius: 5px;
     background-color: transparent;
-    color: var(--text-primary);
+    color: var(--text-color);
     font-size: 16px;
 }
 
@@ -91,10 +69,10 @@ h1 {
     top: 50%;
     left: 10px;
     transform: translateY(-50%);
-    color: var(--text-secondary);
+    color: var(--secondary-text-color);
     pointer-events: none;
     transition: all 0.3s ease;
-    background-color: var(--surface);
+    background-color: var(--surface-color);
     padding: 0 4px;
     z-index: 1;
 }
@@ -104,13 +82,13 @@ h1 {
     top: 0;
     left: 10px;
     font-size: 12px;
-    color: var(--accent-start);
+    color: var(--accent-color);
 }
 
 .input-group input:focus {
-    border-color: var(--accent-start);
+    border-color: var(--accent-color);
     outline: none;
-    box-shadow: 0 0 5px var(--accent-start);
+    box-shadow: 0 0 5px var(--accent-color);
 }
 
 .toggle-password {
@@ -124,7 +102,7 @@ h1 {
 .toggle-password svg {
     width: 24px;
     height: 24px;
-    stroke: var(--text-secondary);
+    stroke: var(--secondary-text-color);
 }
 
 .toggle-password .eye-slash {
@@ -134,7 +112,7 @@ h1 {
 button {
     width: 100%;
     padding: 10px;
-    background-color: var(--button);
+    background-color: var(--button-color);
     color: #FFFFFF;
     border: none;
     border-radius: 5px;
@@ -150,11 +128,11 @@ button:hover {
 p {
     text-align: center;
     margin-top: 20px;
-    color: var(--text-secondary);
+    color: var(--secondary-text-color);
 }
 
 p a {
-    color: var(--accent-start);
+    color: var(--accent-color);
     text-decoration: none;
 }
 

--- a/src/app/static/register/register.css
+++ b/src/app/static/register/register.css
@@ -4,32 +4,10 @@
     padding: 0;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background: #181A20;
-        --surface: #22232B;
-        --text-primary: #FFFFFF;
-        --text-secondary: #A3A6B7;
-        --button: #0057fa;
-        --accent-start: #4F8CFF;
-        --accent-end: #B94EFF;
-    }
-}
-@media (prefers-color-scheme: light) {
-    :root {
-        --background: #F6F8FB;
-        --surface: #FFFFFF;
-        --text-primary: #181A20;
-        --text-secondary: #7D8193;
-        --button: #2464DB;
-        --accent-start: #4F8CFF;
-        --accent-end: #B94EFF;
-    }
-}
 
 body {
-    background-color: var(--background);
-    color: var(--text-primary);
+    background-color: var(--background-color);
+    color: var(--text-color);
     font-family: Arial, sans-serif;
     display: flex;
     justify-content: center;
@@ -39,7 +17,7 @@ body {
 
 .container {
     position: relative;
-    background-color: var(--surface);
+    background-color: var(--surface-color);
     padding: 40px;
     border-radius: 10px;
     box-shadow: 0 4px 10px rgba(0,0,0,0.2);
@@ -52,13 +30,13 @@ body {
     top: 20px;
     left: 20px;
     font-size: 20px;
-    color: var(--text-secondary);
+    color: var(--secondary-text-color);
     text-decoration: none;
     z-index: 2;
 }
 
 .back-arrow:hover {
-    color: var(--accent-start);
+    color: var(--accent-color);
 }
 
 h1 {
@@ -75,10 +53,10 @@ h1 {
 .input-group input {
     width: 100%;
     padding: 10px;
-    border: 1px solid var(--text-secondary);
+    border: 1px solid var(--secondary-text-color);
     border-radius: 5px;
     background-color: transparent;
-    color: var(--text-primary);
+    color: var(--text-color);
     font-size: 16px;
 }
 
@@ -91,10 +69,10 @@ h1 {
     top: 50%;
     left: 10px;
     transform: translateY(-50%);
-    color: var(--text-secondary);
+    color: var(--secondary-text-color);
     pointer-events: none;
     transition: all 0.3s ease;
-    background-color: var(--surface);
+    background-color: var(--surface-color);
     padding: 0 4px;
     z-index: 1;
 }
@@ -104,13 +82,13 @@ h1 {
     top: 0;
     left: 10px;
     font-size: 12px;
-    color: var(--accent-start);
+    color: var(--accent-color);
 }
 
 .input-group input:focus {
-    border-color: var(--accent-start);
+    border-color: var(--accent-color);
     outline: none;
-    box-shadow: 0 0 5px var(--accent-start);
+    box-shadow: 0 0 5px var(--accent-color);
 }
 
 .toggle-password {
@@ -124,7 +102,7 @@ h1 {
 .toggle-password svg {
     width: 24px;
     height: 24px;
-    stroke: var(--text-secondary);
+    stroke: var(--secondary-text-color);
 }
 
 .toggle-password .eye-slash {
@@ -134,7 +112,7 @@ h1 {
 button {
     width: 100%;
     padding: 10px;
-    background-color: var(--button);
+    background-color: var(--button-color);
     color: #FFFFFF;
     border: none;
     border-radius: 5px;
@@ -150,11 +128,11 @@ button:hover {
 p {
     text-align: center;
     margin-top: 20px;
-    color: var(--text-secondary);
+    color: var(--secondary-text-color);
 }
 
 p a {
-    color: var(--accent-start);
+    color: var(--accent-color);
     text-decoration: none;
 }
 

--- a/src/app/templates/board.html
+++ b/src/app/templates/board.html
@@ -9,11 +9,13 @@
         }
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/static/base/base.css">
     <link rel="stylesheet" href="/static/board/board.css">
     <script>
         const boardId = "{{ board_id }}";
     </script>
     <script src="/static/board/board.js" defer></script>
+    <script src="/static/base/base.js" defer></script>
 </head>
 <body>
     <div class="game-container">

--- a/src/app/templates/login.html
+++ b/src/app/templates/login.html
@@ -8,6 +8,7 @@
             document.documentElement.classList.add('dark-mode');
         }
     </script>
+    <link rel="stylesheet" href="/static/base/base.css">
     <link rel="stylesheet" href="/static/login/login.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
@@ -35,5 +36,6 @@
         <p>Нет аккаунта? <a href="/register">Зарегистрироваться</a></p>
     </main>
     <script src="/static/login/login.js"></script>
+    <script src="/static/base/base.js" defer></script>
 </body>
 </html>

--- a/src/app/templates/profile.html
+++ b/src/app/templates/profile.html
@@ -10,6 +10,7 @@
     </script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/static/base/base.css">
     <link rel="stylesheet" href="/static/profile/profile.css">
 </head>
 <body>
@@ -81,5 +82,6 @@
     </main>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="/static/profile/profile.js"></script>
+    <script src="/static/base/base.js" defer></script>
 </body>
 </html>

--- a/src/app/templates/register.html
+++ b/src/app/templates/register.html
@@ -8,6 +8,7 @@
             document.documentElement.classList.add('dark-mode');
         }
     </script>
+    <link rel="stylesheet" href="/static/base/base.css">
     <link rel="stylesheet" href="/static/register/register.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
@@ -52,5 +53,6 @@
         <p>Уже зарегистрированы? <a href="/login">Войти</a></p>
     </main>
     <script src="/static/register/register.js"></script>
+    <script src="/static/base/base.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include common base styles/scripts on all pages
- unify theme variables across login, register and board styles
- default to light theme and keep profile toggle working everywhere

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b40d589cc8326b159c01a2aacaf20